### PR TITLE
[QUICK] JCN-default-id-field-fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- MongoDB default index `_id_` is now ignored when getting current indexes from database
+
 ## [1.1.0] - 2019-12-12
 ### Added
 - `executeForClientCode` method for creating indexes for the specified client databases

--- a/lib/mongodb-index-creator.js
+++ b/lib/mongodb-index-creator.js
@@ -12,6 +12,8 @@ const logger = require('./utils/colorful-lllog')();
 
 const DEFAULT_SCHEMAS_PATH = path.join(process.cwd(), 'schemas', 'mongo');
 
+const DEFAULT_ID_INDEX_NAME = '_id_';
+
 class MongodbIndexCreator {
 
 	constructor(schemasPath) {
@@ -185,7 +187,7 @@ class MongodbIndexCreator {
 		if(!Array.isArray(indexes))
 			return [];
 
-		return indexes.map(({ key, name, unique }) => ({ key, name, unique }));
+		return indexes.map(({ key, name, unique }) => ({ key, name, unique })).filter(({ name }) => name !== DEFAULT_ID_INDEX_NAME);
 	}
 
 	_getIndexesDifference(indexesA, indexesB) {

--- a/tests/mongodb-index-creator-test.js
+++ b/tests/mongodb-index-creator-test.js
@@ -196,6 +196,11 @@ describe('MongodbIndexCreator', () => {
 			FakeMongoDB.prototype.indexes.onFirstCall()
 				.returns([
 					{
+						name: '_id_',
+						key: { _id: 1 },
+						unique: true
+					},
+					{
 						name: 'existingIndex',
 						key: { existingIndex: 1 }
 					}
@@ -204,6 +209,11 @@ describe('MongodbIndexCreator', () => {
 			FakeMongoDB.prototype.indexes.onSecondCall()
 				.returns([
 					{
+						name: '_id_',
+						key: { _id: 1 },
+						unique: true
+					},
+					{
 						name: 'existingIndex',
 						key: { existingIndex: 1 }
 					}
@@ -211,6 +221,11 @@ describe('MongodbIndexCreator', () => {
 
 			FakeMongoDB.prototype.indexes.onThirdCall()
 				.returns([
+					{
+						name: '_id_',
+						key: { _id: 1 },
+						unique: true
+					},
 					{
 						name: 'deprecatedIndex',
 						key: { deprecatedIndex: 1 }


### PR DESCRIPTION
**[QUICK] JCN-DEFAULT-ID-FIELD-FIX**
Ignorar el indice predeterminado "_id_" de mongodb en el proceso

**DESCRIPCIÓN DE LA SOLUCIÓN**
El package ahora ignora el indice predeterminado de mongodb