### PR TITLE
JCN-237-collection-fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Unexisting target DBs or collections crashes the execution
+
 ## [1.1.2] - 2020-01-16
 ### Changed
 - Splitted internal methods into helper modules

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ const mongodbIndexCreator = new MongodbIndexCreator();
 ```
 
 ## Notes
-- **If the schemas files contains indexes for collections that not exists in the target database, the process will fail.**
+- **If the schemas files contains indexes for databases and/or collections that not exists, they will be created in the process.**
 
 ## Errors
 

--- a/lib/helpers/indexes.js
+++ b/lib/helpers/indexes.js
@@ -16,9 +16,15 @@ class IndexesHelper {
 
 	static async get(modelInstance) {
 
-		const indexes = await modelInstance.getIndexes();
+		try {
 
-		return indexes.filter(({ name }) => name !== DEFAULT_ID_INDEX_NAME);
+			const indexes = await modelInstance.getIndexes();
+			return indexes.filter(({ name }) => name !== DEFAULT_ID_INDEX_NAME);
+
+		} catch(err) {
+			// Should return an empty array when the target DB or collection not exists
+			return [];
+		}
 	}
 
 	static difference(indexesA, indexesB) {

--- a/lib/helpers/results.js
+++ b/lib/helpers/results.js
@@ -14,7 +14,11 @@ class ResultsHelper {
 	}
 
 	static export() {
-		return `Changes summary:\n${JSON.stringify(this.results, null, 2)}`;
+
+		if(this.results)
+			return `Changes summary:\n${JSON.stringify(this.results, null, 2)}`;
+
+		return 'No changes applied';
 	}
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@janiscommerce/mongodb-index-creator",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tests/mongodb-index-creator-test.js
+++ b/tests/mongodb-index-creator-test.js
@@ -275,7 +275,7 @@ describe('MongodbIndexCreator', () => {
 				.returns(true);
 
 			sandbox.stub(Model.prototype, 'getIndexes')
-				.returns([]);
+				.rejects();
 		});
 
 		const mongodbIndexCreator = new MongodbIndexCreator();


### PR DESCRIPTION
**LINK AL TICKET**
[https://fizzmod.atlassian.net/browse/JCN-237](https://fizzmod.atlassian.net/browse/JCN-237)

**DESCRIPCIÓN DEL REQUERIMIENTO**
Actualmente, al intentar crear indexes en una base y/o colección que no existen, el package mongodb-index-creator falla. Esto sucede porque se intentan obtener los indices “actuales” de la colección para comparar con los que se quiere crear.

Al fallar, el package mongodb devuelve el siguiente error:

MongoDBError: ns does not exist: MYDB.MYCOLECCION

Requerimiento
Para solucionar este problema se requiere salvar este error con un try catch() y continuar la ejecución asumiendo que no hay indices en la colección.

DESCRIPCIÓN DE LA SOLUCIÓN
Se soluciono el problema agarrando el error con el try catch.